### PR TITLE
Add Rocket.Chat config flow and events

### DIFF
--- a/homeassistant/components/rocketchat/__init__.py
+++ b/homeassistant/components/rocketchat/__init__.py
@@ -1,1 +1,64 @@
-"""The rocketchat component."""
+"""The Rocket.Chat integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .config_flow import RocketChatOptionsFlowHandler, create_options_flow
+from .const import CONF_USER_ID, DOMAIN, PLATFORMS
+from .ddp import RocketChatDDPClient
+
+
+type RocketChatConfigEntry = ConfigEntry
+
+
+@dataclass
+class RocketChatRuntimeData:
+    """Container for integration runtime data."""
+
+    client: RocketChatDDPClient
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: RocketChatConfigEntry) -> bool:
+    """Set up Rocket.Chat from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+    session = async_get_clientsession(hass)
+    client = RocketChatDDPClient(
+        hass,
+        session,
+        entry.data[CONF_URL],
+        entry.data[CONF_USER_ID],
+        entry.data[CONF_TOKEN],
+    )
+    await client.async_connect()
+
+    hass.data[DOMAIN][entry.entry_id] = RocketChatRuntimeData(client)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: RocketChatConfigEntry) -> bool:
+    """Unload a Rocket.Chat config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok and (runtime := hass.data[DOMAIN].pop(entry.entry_id, None)):
+        await runtime.client.async_close()
+    return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Handle migration of config entries."""
+
+    return True
+
+
+async def async_get_options_flow(config_entry: ConfigEntry) -> RocketChatOptionsFlowHandler:
+    """Return the options flow handler factory."""
+
+    return create_options_flow(config_entry)

--- a/homeassistant/components/rocketchat/config_flow.py
+++ b/homeassistant/components/rocketchat/config_flow.py
@@ -1,0 +1,171 @@
+"""Config flow for the Rocket.Chat integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from aiohttp import ClientError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_TOKEN, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONF_CHANNELS, CONF_USER_ID, DOMAIN
+from .ddp import RocketChatClientError, RocketChatDDPClient
+
+
+async def _async_get_client(
+    hass: HomeAssistant, user_input: Mapping[str, Any]
+) -> RocketChatDDPClient:
+    """Create and authenticate a client for config flow validation."""
+
+    session = async_get_clientsession(hass)
+    client = RocketChatDDPClient(
+        hass,
+        session,
+        user_input[CONF_URL],
+        user_input[CONF_USER_ID],
+        user_input[CONF_TOKEN],
+    )
+    await client.async_connect()
+    return client
+
+
+class RocketChatConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Rocket.Chat."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+
+        self._auth_input: dict[str, Any] | None = None
+        self._channels: dict[str, str] = {}
+
+    async def async_step_user(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+
+        errors: dict[str, str] = {}
+        client: RocketChatDDPClient | None = None
+        if user_input:
+            try:
+                client = await _async_get_client(self.hass, user_input)
+                channels = await client.async_list_channels()
+            except RocketChatClientError:
+                errors["base"] = "cannot_connect"
+            except ClientError:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(user_input[CONF_USER_ID])
+                self._abort_if_unique_id_configured()
+                self._auth_input = dict(user_input)
+                self._channels = {
+                    channel.identifier: channel.name for channel in channels
+                }
+                return await self.async_step_channels()
+            finally:
+                if client is not None:
+                    await client.async_close()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_URL): str,
+                vol.Required(CONF_USER_ID): str,
+                vol.Required(CONF_TOKEN): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_channels(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle channel selection."""
+
+        assert self._auth_input is not None
+        errors: dict[str, str] = {}
+
+        if user_input:
+            if not user_input[CONF_CHANNELS]:
+                errors["base"] = "no_channels"
+            else:
+                data = {
+                    **self._auth_input,
+                    CONF_CHANNELS: [
+                        {"id": channel_id, "name": self._channels[channel_id]}
+                        for channel_id in user_input[CONF_CHANNELS]
+                    ],
+                }
+                return self.async_create_entry(title=self._auth_input[CONF_URL], data=data)
+
+        if not self._channels:
+            errors["base"] = "no_channels"
+
+        return self.async_show_form(
+            step_id="channels",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_CHANNELS, default=list(self._channels)): cv.multi_select(self._channels)}
+            ),
+            errors=errors,
+        )
+
+
+class RocketChatOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Rocket.Chat options flows."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize the options flow."""
+
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage options for the integration."""
+
+        errors: dict[str, str] = {}
+        client: RocketChatDDPClient | None = None
+        if user_input:
+            return self.async_create_entry(title="", data=user_input)
+
+        hass = self.hass
+        try:
+            client = await _async_get_client(hass, self.config_entry.data)
+            channels = await client.async_list_channels()
+        except (RocketChatClientError, ClientError):
+            errors["base"] = "cannot_connect"
+            channels = []
+        finally:
+            if client is not None:
+                await client.async_close()
+
+        existing_channels = self.config_entry.data.get(CONF_CHANNELS, [])
+        existing_ids = [channel["id"] for channel in existing_channels]
+        channel_map = {channel.identifier: channel.name for channel in channels}
+
+        if not channel_map:
+            errors["base"] = errors.get("base", "no_channels")
+
+        default_ids = [channel_id for channel_id in existing_ids if channel_id in channel_map]
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_CHANNELS, default=default_ids): cv.multi_select(channel_map)}
+            ),
+            errors=errors,
+        )
+
+
+def create_options_flow(
+    config_entry: config_entries.ConfigEntry,
+) -> RocketChatOptionsFlowHandler:
+    """Create the options flow handler."""
+
+    return RocketChatOptionsFlowHandler(config_entry)

--- a/homeassistant/components/rocketchat/const.py
+++ b/homeassistant/components/rocketchat/const.py
@@ -1,0 +1,12 @@
+"""Constants for the Rocket.Chat integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "rocketchat"
+
+CONF_CHANNELS = "channels"
+CONF_USER_ID = "user_id"
+
+PLATFORMS = [Platform.EVENT]
+
+EVENT_TYPE_MESSAGE = "message"

--- a/homeassistant/components/rocketchat/ddp.py
+++ b/homeassistant/components/rocketchat/ddp.py
@@ -1,0 +1,226 @@
+"""Async Rocket.Chat DDP client."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import asyncio
+import json
+import logging
+from typing import Any
+
+from aiohttp import ClientConnectionError, ClientSession, ClientWebSocketResponse, WSMsgType
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import EVENT_TYPE_MESSAGE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RocketChatChannel:
+    """Representation of a Rocket.Chat channel."""
+
+    identifier: str
+    name: str
+
+
+class RocketChatClientError(HomeAssistantError):
+    """Raised when the Rocket.Chat client encounters an error."""
+
+
+class RocketChatDDPClient:
+    """Simple DDP client for Rocket.Chat websocket APIs."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        session: ClientSession,
+        url: str,
+        user_id: str,
+        token: str,
+    ) -> None:
+        """Initialize the DDP client."""
+
+        self._hass = hass
+        self._session = session
+        self._url = url.rstrip("/")
+        self._user_id = user_id
+        self._token = token
+        self._ws: ClientWebSocketResponse | None = None
+        self._listener_task: asyncio.Task | None = None
+        self._message_id = 0
+        self._pending_results: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._subscriptions: dict[str, Callable[[dict[str, Any]], None]] = {}
+
+    async def async_connect(self) -> None:
+        """Open the websocket and authenticate."""
+
+        if self._ws is not None:
+            return
+
+        try:
+            self._ws = await self._session.ws_connect(
+                f"{self._url}/websocket", heartbeat=30
+            )
+        except ClientConnectionError as err:
+            raise RocketChatClientError("Failed to connect to Rocket.Chat") from err
+
+        await self._send_json({"msg": "connect", "version": "1", "support": ["1"]})
+        response = await self._receive_message()
+        if response.get("msg") != "connected":
+            raise RocketChatClientError("Rocket.Chat did not accept DDP connection")
+
+        result = await self._call_method(
+            "login", {"resume": self._token}, expected_key="id"
+        )
+        user_id = result.get("id") if isinstance(result, dict) else None
+        if user_id != self._user_id:
+            raise RocketChatClientError("Rocket.Chat login failed")
+
+        self._listener_task = self._hass.async_create_task(self._message_listener())
+
+    async def async_close(self) -> None:
+        """Close the websocket connection."""
+
+        if self._listener_task:
+            self._listener_task.cancel()
+
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+
+    async def async_list_channels(self) -> list[RocketChatChannel]:
+        """Return available channels for the authenticated user."""
+
+        result = await self._call_method("rooms.get", None)
+        if not isinstance(result, dict):
+            raise RocketChatClientError("Unexpected response when listing channels")
+
+        rooms = result.get("update") or []
+        channels: list[RocketChatChannel] = []
+        for room in rooms:
+            if not isinstance(room, dict):
+                continue
+            room_id = room.get("_id")
+            if not isinstance(room_id, str):
+                continue
+            name = room.get("name") or room.get("fname") or room_id
+            channels.append(RocketChatChannel(room_id, str(name)))
+        return channels
+
+    async def async_subscribe_room(
+        self, room_id: str, message_callback: Callable[[dict[str, Any]], None]
+    ) -> CALLBACK_TYPE:
+        """Subscribe to message events for a room."""
+
+        sub_id = self._next_message_id()
+        self._subscriptions[sub_id] = message_callback
+        await self._send_json(
+            {
+                "msg": "sub",
+                "id": sub_id,
+                "name": "stream-room-messages",
+                "params": [room_id, False],
+            }
+        )
+
+        @callback
+        def _unsub() -> None:
+            self._subscriptions.pop(sub_id, None)
+            if self._ws is not None:
+                self._hass.async_create_task(
+                    self._send_json({"msg": "unsub", "id": sub_id})
+                )
+
+        return _unsub
+
+    async def _call_method(
+        self, method: str, params: Any | None, expected_key: str | None = "result"
+    ) -> Any:
+        """Send a DDP method request and return the result."""
+
+        if self._ws is None:
+            raise RocketChatClientError("Websocket is not connected")
+
+        msg_id = self._next_message_id()
+        future: asyncio.Future[dict[str, Any]] = self._hass.loop.create_future()
+        self._pending_results[msg_id] = future
+        await self._send_json(
+            {"msg": "method", "method": method, "params": [params], "id": msg_id}
+        )
+
+        if self._listener_task:
+            await future
+        else:
+            await self._wait_for_result(msg_id)
+
+        data = future.result()
+        if expected_key is None:
+            return data
+        if expected_key not in data:
+            raise RocketChatClientError(f"Missing {expected_key} in method response")
+        return data[expected_key]
+
+    async def _wait_for_result(self, msg_id: str) -> None:
+        """Wait for a method result message."""
+
+        while msg_id in self._pending_results:
+            await self._receive_message()
+
+    async def _message_listener(self) -> None:
+        """Listen for incoming messages and dispatch callbacks."""
+
+        assert self._ws is not None
+        async for message in self._ws:
+            if message.type == WSMsgType.TEXT:
+                data = json.loads(message.data)
+                await self._handle_message(data)
+            elif message.type == WSMsgType.ERROR:
+                _LOGGER.warning("Rocket.Chat websocket closed unexpectedly")
+                break
+
+    async def _handle_message(self, data: dict[str, Any]) -> None:
+        """Process a single websocket message."""
+
+        if data.get("msg") == "ping":
+            await self._send_json({"msg": "pong"})
+            return
+
+        if data.get("msg") == "result":
+            if future := self._pending_results.pop(data["id"], None):
+                if not future.done():
+                    future.set_result(data)
+            return
+
+        if data.get("msg") == "changed" and data.get("collection") == "stream-room-messages":
+            if (callback := self._subscriptions.get(data.get("id"))) is None:
+                return
+            fields = data.get("fields") or {}
+            for payload in fields.get("args", []):
+                callback({"event_type": EVENT_TYPE_MESSAGE, "payload": payload})
+
+    async def _receive_message(self) -> dict[str, Any]:
+        """Receive a single websocket message."""
+
+        assert self._ws is not None
+        message = await self._ws.receive()
+        if message.type != WSMsgType.TEXT:
+            raise RocketChatClientError("Unexpected websocket message type")
+        data = json.loads(message.data)
+        await self._handle_message(data)
+        return data
+
+    async def _send_json(self, payload: dict[str, Any]) -> None:
+        """Send a JSON payload on the websocket."""
+
+        assert self._ws is not None
+        await self._ws.send_json(payload)
+
+    def _next_message_id(self) -> str:
+        """Return the next message id."""
+
+        self._message_id += 1
+        return str(self._message_id)

--- a/homeassistant/components/rocketchat/event.py
+++ b/homeassistant/components/rocketchat/event.py
@@ -1,0 +1,66 @@
+"""Event entities for Rocket.Chat channels."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.event import EventEntity
+from homeassistant.core import callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_CHANNELS, DOMAIN, EVENT_TYPE_MESSAGE
+
+
+async def async_setup_entry(
+    hass, entry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Rocket.Chat events from a config entry."""
+
+    channels = entry.options.get(CONF_CHANNELS, entry.data[CONF_CHANNELS])
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        RocketChatChannelEvent(
+            runtime.client, entry.entry_id, channel_data["id"], channel_data["name"]
+        )
+        for channel_data in channels
+    ]
+    async_add_entities(entities)
+
+
+class RocketChatChannelEvent(EventEntity):
+    """Representation of a Rocket.Chat room as an event entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, client, entry_id: str, room_id: str, name: str) -> None:
+        """Initialize the event entity."""
+
+        self._client = client
+        self._room_id = room_id
+        self._unsub = None
+        self._attr_unique_id = f"{entry_id}_{room_id}"
+        self._attr_event_types = [EVENT_TYPE_MESSAGE]
+        self._attr_name = name
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity added to hass."""
+
+        await super().async_added_to_hass()
+        self._unsub = await self._client.async_subscribe_room(
+            self._room_id, self._handle_message
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Handle entity removal."""
+
+        if self._unsub:
+            self._unsub()
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_message(self, payload: dict[str, Any]) -> None:
+        """Process an incoming message event."""
+
+        self._trigger_event(EVENT_TYPE_MESSAGE, payload)
+        self.async_write_ha_state()

--- a/homeassistant/components/rocketchat/manifest.json
+++ b/homeassistant/components/rocketchat/manifest.json
@@ -3,6 +3,7 @@
   "name": "Rocket.Chat",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/rocketchat",
+  "config_flow": true,
   "iot_class": "cloud_push",
   "loggers": ["rocketchat_API"],
   "quality_scale": "legacy",

--- a/homeassistant/components/rocketchat/strings.json
+++ b/homeassistant/components/rocketchat/strings.json
@@ -1,0 +1,40 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Rocket.Chat verbinden",
+        "description": "Verbinde Home Assistant mit deinem Rocket.Chat Server.",
+        "data": {
+          "url": "Server-URL",
+          "user_id": "Benutzer-ID",
+          "token": "Persönlicher Token"
+        }
+      },
+      "channels": {
+        "title": "Kanäle auswählen",
+        "description": "Wähle die Kanäle aus, die als Ereignisse verfügbar sein sollen.",
+        "data": {
+          "channels": "Kanäle"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen. Bitte Daten prüfen.",
+      "no_channels": "Keine Kanäle gefunden."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Kanäle aktualisieren",
+        "data": {
+          "channels": "Aktive Kanäle"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen.",
+      "no_channels": "Keine Kanäle gefunden."
+    }
+  }
+}

--- a/homeassistant/components/rocketchat/translations/en.json
+++ b/homeassistant/components/rocketchat/translations/en.json
@@ -1,0 +1,40 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect Rocket.Chat",
+        "description": "Connect Home Assistant to your Rocket.Chat server.",
+        "data": {
+          "url": "Server URL",
+          "user_id": "User ID",
+          "token": "Personal token"
+        }
+      },
+      "channels": {
+        "title": "Select channels",
+        "description": "Choose the channels to expose as event entities.",
+        "data": {
+          "channels": "Channels"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect. Please check the details.",
+      "no_channels": "No channels were found."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Update channels",
+        "data": {
+          "channels": "Active channels"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect.",
+      "no_channels": "No channels were found."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add UI config flow for Rocket.Chat that authenticates over DDP and lists channels to monitor
- implement websocket DDP client and event entities that fire on new channel messages
- enable options flow support and mark the integration as config_flow capable

## Testing
- python -m compileall homeassistant/components/rocketchat

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926497706e48324915be545a32e07cd)